### PR TITLE
feat: enable log level control at top-level

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -119,6 +119,11 @@
       "type": "runtime"
     },
     {
+      "name": "loglevel",
+      "version": "^1.8.0",
+      "type": "runtime"
+    },
+    {
       "name": "yargs-parser",
       "version": "^21.0.1",
       "type": "runtime"

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -232,7 +232,7 @@
           "exec": "yarn install --check-files"
         },
         {
-          "exec": "yarn upgrade @time-loop/clickup-projen @types/jest @types/node @typescript-eslint/eslint-plugin @typescript-eslint/parser aws-sdk-client-mock esbuild eslint-config-prettier eslint-import-resolver-node eslint-import-resolver-typescript eslint-plugin-import eslint-plugin-prettier eslint jest jest-junit jsii-release json-schema npm-check-updates prettier standard-version ts-jest ts-node typescript @aws-sdk/client-elastic-beanstalk @time-loop/clickup-projen chalk yargs-parser"
+          "exec": "yarn upgrade @time-loop/clickup-projen @types/jest @types/node @typescript-eslint/eslint-plugin @typescript-eslint/parser aws-sdk-client-mock esbuild eslint-config-prettier eslint-import-resolver-node eslint-import-resolver-typescript eslint-plugin-import eslint-plugin-prettier eslint jest jest-junit jsii-release json-schema npm-check-updates prettier standard-version ts-jest ts-node typescript @aws-sdk/client-elastic-beanstalk @time-loop/clickup-projen chalk loglevel yargs-parser"
         },
         {
           "exec": "npx projen"

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -5,7 +5,7 @@ const project = new clickupTs.ClickUpTypeScriptProject({
   name: 'deploy-beanstalk',
 
   /* Runtime dependencies of this module. */
-  deps: ['@aws-sdk/client-elastic-beanstalk@^3.54.1', 'chalk@^4.1.2', 'yargs-parser@^21.0.1'],
+  deps: ['@aws-sdk/client-elastic-beanstalk@^3.54.1', 'chalk@^4.1.2', 'loglevel@^1.8.0', 'yargs-parser@^21.0.1'],
   tsconfig: {
     compilerOptions: {
       lib: ['es2020'],

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "@aws-sdk/client-elastic-beanstalk": "^3.54.1",
     "@time-loop/clickup-projen": "^0.0.25",
     "chalk": "^4.1.2",
+    "loglevel": "^1.8.0",
     "yargs-parser": "^21.0.1"
   },
   "engines": {

--- a/src/helpers/Interfaces.ts
+++ b/src/helpers/Interfaces.ts
@@ -1,4 +1,5 @@
 import { S3Location } from '@aws-sdk/client-elastic-beanstalk';
+import log from 'loglevel';
 
 /**
  * Properties consumed to deploy an Application Version to an existing
@@ -51,4 +52,22 @@ export interface IAppVersionProps {
    * exists, do we error or continue?
    */
   readonly errorIfExists: boolean;
+}
+
+/**
+ * Everything required to deploy to a group of Beanstalk Environments.
+ */
+export interface IDeployToGroupProps {
+  /**
+   * The list of Beanstalk Environment to deploy to.
+   */
+  readonly group: IBeanstalkGroup;
+  /**
+   * If false, will perform a no-op describing what would occur. Defaults to false.
+   */
+  readonly force?: boolean;
+  /**
+   * Every level below the specified log level is silenced. Defaults to INFO.
+   */
+  readonly logLevel?: log.LogLevelDesc;
 }

--- a/src/helpers/create-app-version.ts
+++ b/src/helpers/create-app-version.ts
@@ -4,6 +4,7 @@ import {
   DescribeApplicationVersionsCommand,
   ElasticBeanstalkClient,
 } from '@aws-sdk/client-elastic-beanstalk';
+import log from 'loglevel';
 import { DBCreateApplicationVersionError } from './Errors';
 import { IAppVersionProps } from './Interfaces';
 
@@ -25,7 +26,7 @@ async function checkApplicationVersionExists(props: ICreateProps): Promise<boole
 
 async function createApplicationVersion(props: ICreateProps): Promise<void> {
   if (props.dryRun) {
-    console.log(`DRY RUN: Would have created application version ${props.version.label} for app ${props.appName}`);
+    log.info(`DRY RUN: Would have created application version ${props.version.label} for app ${props.appName}`);
     return;
   }
 
@@ -37,13 +38,13 @@ async function createApplicationVersion(props: ICreateProps): Promise<void> {
     VersionLabel: props.version.label,
   });
 
-  console.log(`Creating version ${props.version.label} for beanstalk application ${props.appName}`);
+  log.info(`Creating version ${props.version.label} for beanstalk application ${props.appName}`);
   const resp = await props.client.send(createVersionCmd);
 
   // Verify OK response
   const statusCode = resp.$metadata.httpStatusCode;
   if (statusCode && statusCode >= 200 && statusCode < 300) {
-    console.log(`New application version labeled '${props.version.label}' created for app ${props.appName}.`);
+    log.info(`New application version labeled '${props.version.label}' created for app ${props.appName}.`);
   } else {
     throw new Error(`Create application version failed for app ${props.appName}. Response metadata: ${resp.$metadata}`);
   }
@@ -61,7 +62,7 @@ export async function create(props: ICreateProps): Promise<void> {
       if (props.version.errorIfExists ?? false) {
         throw new Error(`Failed to create new application version ${props.version.label}, it already exists.`);
       }
-      console.log(
+      log.info(
         `Not creating new application version ${props.version.label} for app ${props.appName} since it already exists.`,
       );
     } else {

--- a/test/deploy.test.ts
+++ b/test/deploy.test.ts
@@ -12,20 +12,13 @@ import {
   DBDeployApplicationVersionError,
   deployToGroup,
   IBeanstalkGroup,
+  IDeployToGroupProps,
 } from '../src/index';
 
 const ebMock = mockClient(ElasticBeanstalkClient);
 
 const FORCE_DEPLOYMENT = true;
 let TEST_BEANSTALK_GROUP: IBeanstalkGroup;
-
-// Silence all log output for tests
-global.console = {
-  ...global.console,
-  log: jest.fn(),
-  debug: jest.fn(),
-  error: jest.fn(),
-};
 
 // Must reset client prior to each test
 // https://aws.amazon.com/blogs/developer/mocking-modular-aws-sdk-for-javascript-v3-in-unit-tests/
@@ -57,6 +50,12 @@ describe('Deployment to beanstalks in different apps', () => {
     region: 'us-west-2',
   };
 
+  const commonDeployProps: IDeployToGroupProps = {
+    group: TEST_BEANSTALK_GROUP,
+    force: FORCE_DEPLOYMENT,
+    logLevel: 'SILENT',
+  };
+
   // Defines mock functions for AWS EB Client
   beforeEach(() => {
     ebMock.on(CreateApplicationVersionCommand).resolves({
@@ -79,7 +78,7 @@ describe('Deployment to beanstalks in different apps', () => {
   });
 
   test('succeeds when AWS client does', async () => {
-    expect(await deployToGroup(TEST_BEANSTALK_GROUP, FORCE_DEPLOYMENT)).not.toThrowError;
+    expect(await deployToGroup(commonDeployProps)).not.toThrowError;
   });
 
   test('throws error when version already exists', async () => {
@@ -90,7 +89,7 @@ describe('Deployment to beanstalks in different apps', () => {
     expect.assertions(3);
     const expectedErrCount = 2;
     try {
-      await deployToGroup(TEST_BEANSTALK_GROUP, FORCE_DEPLOYMENT);
+      await deployToGroup(commonDeployProps);
     } catch (e) {
       expect(e).toBeInstanceOf(DBAsyncError);
       const errs = (e as DBAsyncError).errors;
@@ -115,7 +114,7 @@ describe('Deployment to beanstalks in different apps', () => {
     expect.assertions(3);
     const expectedErrCount = 1;
     try {
-      await deployToGroup(TEST_BEANSTALK_GROUP, FORCE_DEPLOYMENT);
+      await deployToGroup(commonDeployProps);
     } catch (e) {
       expect(e).toBeInstanceOf(DBAsyncError);
       const errs = (e as DBAsyncError).errors;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4632,6 +4632,11 @@ lodash@^4.17.15, lodash@^4.17.21, lodash@^4.7.0:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
+loglevel@^1.8.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.8.0.tgz#e7ec73a57e1e7b419cb6c6ac06bf050b67356114"
+  integrity sha512-G6A/nJLRgWOuuwdNuA6koovfEV1YpqqAG4pRUlFaz3jj2QNZ8M4vBqnVA+HBTmU/AMNUtlOsMmSpF6NyOjztbA==
+
 lowercase-keys@^1.0.0, lowercase-keys@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-1.0.1.tgz#6f9e30b47084d971a7c820ff15a6c5167b74c26f"


### PR DESCRIPTION
Introduces [loglevel](https://www.npmjs.com/package/loglevel) package, a very lightweight and minimal logging library. Is meant to Just Work.

The `IDeployToGroupProps` interface can be used in the next iteration. We can add an attribute to it, something like `waitTimeForHealthiness`, to control how long we wait for a group to be healthy.

For now, the extra added attribute allows us to control how much we want to log. DEBUG mode for example will output Beanstalk Environment health response from AWS. Just INFO will provide the human-readable version of that.