### PR TITLE
chore: update required perms for PAT

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ To install the package in a project (especially locally), you'll first need to s
 
 > ***NOTE:*** If you are working with a GitHub Workflow, the provided `GITHUB_TOKEN` might Just Work for you as this is a public package. However, if you also need to access packages that are private to your org, you might consider adding an `ALL_PACKAGE_READ_TOKEN` org secret followed by populating your .npmrc appropriately.
 
-Once created with at least `read:package` access, in your project follow these steps under [Installing a Package](https://itnext.io/setting-up-github-packages-for-npm-2bc9f8e4b11e) where `@yourcompany` is `@time-loop`.
+Once created with at least `read:package` and `repo` access, in your project follow these steps under [Installing a Package](https://itnext.io/setting-up-github-packages-for-npm-2bc9f8e4b11e) where `@yourcompany` is `@time-loop`.
 
 Then, install with `npm` in your project like so:
 


### PR DESCRIPTION
In order to auth with npm CLI, we also need `repo` access. This was caught by a dev following the instructions.

>  Do we also need any of the repo scope? The npm CLI wouldn't let me auth unless I added the repo scope (it was an explicit error saying I had to add it)

Context: https://click-up.slack.com/archives/C02DM08ER8R/p1649962704492469?thread_ts=1649888109.885319&cid=C02DM08ER8R