### PR TITLE
feat: Configurable unhealthiness status for beanstalk environments

### DIFF
--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -83,12 +83,11 @@ async function deployAppVersionsToGroup(client: ElasticBeanstalkClient, props: I
   try {
     // Verify the group successfully receives the deployment.
     await waitForGroupHealthiness({
-      ...DEFAULT_HEALTH_CHECK_PROPS,
       client,
       group: props.group,
       force,
       checkVersion: true,
-      ...(props.postDeployHealthCheckProps ?? {}),
+      ...(props.postDeployHealthCheckProps ?? DEFAULT_HEALTH_CHECK_PROPS),
     });
     log.info(
       chalk.green('Successfully deployed version ') +
@@ -121,12 +120,11 @@ export async function deployToGroup(props: IDeployToGroupProps) {
     await createAppVersionsForGroup(client, props);
     log.info(chalk.blue('Verifying environments are ready to receive deployment before initiating...'));
     await waitForGroupHealthiness({
-      ...DEFAULT_HEALTH_CHECK_PROPS,
       client,
       group,
       force,
       checkVersion: false,
-      ...(props.preDeployHealthCheckProps ?? {}),
+      ...(props.preDeployHealthCheckProps ?? DEFAULT_HEALTH_CHECK_PROPS),
     });
     await deployAppVersionsToGroup(client, props);
   } catch (e) {

--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -83,11 +83,12 @@ async function deployAppVersionsToGroup(client: ElasticBeanstalkClient, props: I
   try {
     // Verify the group successfully receives the deployment.
     await waitForGroupHealthiness({
+      ...DEFAULT_HEALTH_CHECK_PROPS,
       client,
       group: props.group,
       force,
       checkVersion: true,
-      ...(props.postDeployHealthCheckProps ?? DEFAULT_HEALTH_CHECK_PROPS),
+      ...(props.postDeployHealthCheckProps ?? {}),
     });
     log.info(
       chalk.green('Successfully deployed version ') +
@@ -118,13 +119,14 @@ export async function deployToGroup(props: IDeployToGroupProps) {
       region: group.region,
     });
     await createAppVersionsForGroup(client, props);
-    // Must wait for envs to be healthy before issuing deployment
+    log.info(chalk.blue('Verifying environments are ready to receive deployment before initiating...'));
     await waitForGroupHealthiness({
+      ...DEFAULT_HEALTH_CHECK_PROPS,
       client,
       group,
       force,
       checkVersion: false,
-      ...(props.preDeployHealthCheckProps ?? DEFAULT_HEALTH_CHECK_PROPS),
+      ...(props.preDeployHealthCheckProps ?? {}),
     });
     await deployAppVersionsToGroup(client, props);
   } catch (e) {

--- a/src/helpers/Interfaces.ts
+++ b/src/helpers/Interfaces.ts
@@ -1,4 +1,4 @@
-import { S3Location } from '@aws-sdk/client-elastic-beanstalk';
+import { S3Location, EnvironmentHealthStatus } from '@aws-sdk/client-elastic-beanstalk';
 import log from 'loglevel';
 
 /**
@@ -65,6 +65,11 @@ export interface IHealthCheckProps {
    * @default 60000
    */
   readonly timeBetweenAttemptsMs: number;
+  /**
+   * Which statuses qualify a beanstalk environment as unhealthy.
+   * @default ['Severe', 'Degraded', 'Warning']
+   */
+  readonly unhealthyStatuses?: EnvironmentHealthStatus[];
 }
 
 /**


### PR DESCRIPTION
Right now it's hardcoded that Severe, Degraded, and Warning health statuses for beanstalk environments are considered unhealthy. We want this to be configurable so that the consumer can decide what they qualify as healthy.

This is mostly to allow clickup  to initiate a deploy even when environments are marked as Degraded, which they currently do not. This has the potential to hold up deployments since we cannot determine yet whether the degraded environment contains a Severe instance.