### PR TITLE
fix: Error when beanstalk environment does not exist or is not found

### DIFF
--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -128,10 +128,9 @@ export async function deployToGroup(props: IDeployToGroupProps) {
     });
     await deployAppVersionsToGroup(client, props);
   } catch (e) {
+    log.error(chalk.red(e));
     if (e instanceof DBError) {
       e.errors.forEach((err) => log.error(chalk.red(err)));
-    } else {
-      log.error(chalk.red(e));
     }
     log.error(chalk.red('Deploy to beanstalk group ') + chalk.blue(group.name) + chalk.red(' failed.'));
     throw e;

--- a/src/helpers/healthiness.ts
+++ b/src/helpers/healthiness.ts
@@ -132,7 +132,7 @@ async function getGroupHealth(props: IHealthCheckPropsPrivate): Promise<IBeansta
         throw new Error(`Failed to check status for Environments in App '${key}'`);
       }
 
-      if (resp.Environments.length !== envs.length) {
+      if (resp.Environments.length != envs.length) {
         const missing = envNames.filter((env) => {
           let found = false;
           resp.Environments?.forEach((envDesc) => {

--- a/src/helpers/healthiness.ts
+++ b/src/helpers/healthiness.ts
@@ -120,20 +120,36 @@ async function getGroupHealth(props: IHealthCheckPropsPrivate): Promise<IBeansta
   // For each Application Version
   for (const key in beansToDescribe) {
     if (beansToDescribe.hasOwnProperty(key)) {
-      if (!props.force) {
-        log.info(`DRY RUN: Would have waited for beanstalks in app '${key}' to become healthy.`);
-        continue;
-      }
-
       const envs = beansToDescribe[key];
+      const envNames = envs.map((env) => env.name);
       resp = await props.client.send(
         new DescribeEnvironmentsCommand({
           ApplicationName: key,
-          EnvironmentNames: envs.map((env) => env.name),
+          EnvironmentNames: envNames,
         }),
       );
       if (!resp.Environments) {
         throw new Error(`Failed to check status for Environments in App '${key}'`);
+      }
+
+      if (resp.Environments.length !== envs.length) {
+        const missing = envNames.filter((env) => {
+          let found = false;
+          resp.Environments?.forEach((envDesc) => {
+            if (env === envDesc.EnvironmentName) {
+              found = true;
+            }
+          });
+          return !found;
+        });
+        throw new Error(
+          `The following Beanstalk Environments either do not exist or were not found: ${JSON.stringify(missing)}`,
+        );
+      }
+
+      if (!props.force) {
+        log.info(`DRY RUN: Would have waited for beanstalks in app '${key}' to become healthy.`);
+        continue;
       }
 
       const partitioned = getEnvironmentsHealth(


### PR DESCRIPTION
Task: https://staging.clickup.com/t/333/CLK-91295

Used [yalc](https://github.com/wclr/yalc) to test in `clickup` repo via a test group created containing a non-existent Beanstalk environment. Group defined like so:
```typescript
const testGroup: IGroupFactory = (config: IConfig): ICUBeanstalkGroup => {
    ...
    return {
        environments: [
            {
                app: 'clickup-staging',
                // Definitely does not exist
                name: 'clickup-staging-test-jglo',
            },
        ],
        ...
    };
};
```

Yielded the following on dry-run and force modes:
```plaintext
Configuration: 
{
  "ebGroup": "testGroup",
  "ebAppVersionGitsha": "7b1e725f61414c89f17bf8001ed61e6f2c676bd9",
  "ebAppVersionDescription": "test desc",
  "force": true,
  "logLevel": "info"
}

Beginning deploy process for beanstalk group testGroup
Creating application versions for beanstalk group testGroup
Not creating new application version travis-ebv2-lacework-7b1e725f61414c89f17bf8001ed61e6f2c676bd9 for app clickup-staging since it already exists.
All needed application versions exist.
Verifying environments are ready to receive deployment before initiating...
Checking beanstalks health... Attempt 1 of 10
Error: Could not check group health.
Error: The following Beanstalk Environments either do not exist or were not found: ["clickup-staging-test-jglo"]
Deploy to beanstalk group testGroup failed.
```

```