### PR TITLE
feat: add ability to inject external logger and pass AWS credentials through input props

### DIFF
--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -1,12 +1,11 @@
-/* eslint-disable no-console */
 import { ElasticBeanstalkClient } from '@aws-sdk/client-elastic-beanstalk';
 import chalk from 'chalk';
-import log from 'loglevel';
+import loglevel from 'loglevel';
 import { create } from './helpers/create-app-version';
 import { deploy } from './helpers/deploy-app-version-to-env';
 import { DBError, DBGroupDeployTriggerError, DBHealthinessCheckError } from './helpers/Errors';
 import { waitForGroupHealthiness } from './helpers/healthiness';
-import { IDeployToGroupProps, IHealthCheckProps } from './helpers/Interfaces';
+import { IDeployToGroupProps, IHealthCheckProps, Logger } from './helpers/Interfaces';
 
 const AWS_CLIENT_REQUEST_MAX_ATTEMPTS_DEFAULT = 10;
 const DEFAULT_FORCE = false;
@@ -34,7 +33,7 @@ function verifyPromisesSettled(results: PromiseSettledResult<void>[]) {
  * Application. For each of those unique Applications, we must create an App
  * Version to use for deployments.
  */
-async function createAppVersionsForGroup(client: ElasticBeanstalkClient, props: IDeployToGroupProps) {
+async function createAppVersionsForGroup(client: ElasticBeanstalkClient, props: IDeployToGroupProps, log: Logger) {
   const appsWithCreatedVersions: string[] = [];
   const appVersionPromises: Promise<void>[] = [];
   log.info(`Creating application versions for beanstalk group ${props.group.name}`);
@@ -46,6 +45,7 @@ async function createAppVersionsForGroup(client: ElasticBeanstalkClient, props: 
           version: props.group.versionProps,
           appName: env.app,
           dryRun: !props.force,
+          log,
         }),
       );
       appsWithCreatedVersions.push(env.app);
@@ -56,7 +56,7 @@ async function createAppVersionsForGroup(client: ElasticBeanstalkClient, props: 
   log.info(chalk.green('All needed application versions exist.'));
 }
 
-async function preDeployHealthcheck(client: ElasticBeanstalkClient, props: IDeployToGroupProps) {
+async function preDeployHealthcheck(client: ElasticBeanstalkClient, props: IDeployToGroupProps, log: Logger) {
   try {
     log.info(chalk.blue('Verifying environments are ready to receive deployment before initiating...'));
     await waitForGroupHealthiness({
@@ -64,6 +64,7 @@ async function preDeployHealthcheck(client: ElasticBeanstalkClient, props: IDepl
       group: props.group,
       force: props.force ?? DEFAULT_FORCE,
       checkVersion: false,
+      log,
       ...(props.preDeployHealthCheckProps ?? DEFAULT_HEALTH_CHECK_PROPS),
     });
   } catch (e) {
@@ -74,7 +75,7 @@ async function preDeployHealthcheck(client: ElasticBeanstalkClient, props: IDepl
   }
 }
 
-async function postDeployHealthcheck(client: ElasticBeanstalkClient, props: IDeployToGroupProps) {
+async function postDeployHealthcheck(client: ElasticBeanstalkClient, props: IDeployToGroupProps, log: Logger) {
   log.info(chalk.blue('Verifying environments successfully receive the deployment...this could take a while.'));
   try {
     await waitForGroupHealthiness({
@@ -82,6 +83,7 @@ async function postDeployHealthcheck(client: ElasticBeanstalkClient, props: IDep
       group: props.group,
       force: props.force ?? DEFAULT_FORCE,
       checkVersion: true,
+      log,
       ...(props.postDeployHealthCheckProps ?? DEFAULT_HEALTH_CHECK_PROPS),
     });
   } catch (e) {
@@ -103,7 +105,7 @@ async function postDeployHealthcheck(client: ElasticBeanstalkClient, props: IDep
  * For each Beanstalk Environment in the group, deploys the respective
  * Application Version.
  */
-async function deployAppVersionsToGroup(client: ElasticBeanstalkClient, props: IDeployToGroupProps) {
+async function deployAppVersionsToGroup(client: ElasticBeanstalkClient, props: IDeployToGroupProps, log: Logger) {
   log.info(`Asynchronously kicking off deployment to the ${props.group.name} group of beanstalks.`);
   const triggerErr = new DBGroupDeployTriggerError('deployAppVersionsToGroup: ', []);
   const force = props.force ?? DEFAULT_FORCE;
@@ -114,6 +116,7 @@ async function deployAppVersionsToGroup(client: ElasticBeanstalkClient, props: I
           client,
           force,
           env,
+          log,
           version: props.group.versionProps,
         });
       } catch (e) {
@@ -131,14 +134,14 @@ async function deployAppVersionsToGroup(client: ElasticBeanstalkClient, props: I
  * and verifies the Beanstalk Environments in the group are ready to receive
  * the deployment.
  */
-async function preDeploySteps(props: IDeployToGroupProps): Promise<ElasticBeanstalkClient> {
+async function preDeploySteps(props: IDeployToGroupProps, log: Logger): Promise<ElasticBeanstalkClient> {
   try {
     const client = new ElasticBeanstalkClient({
       maxAttempts: AWS_CLIENT_REQUEST_MAX_ATTEMPTS_DEFAULT,
       region: props.group.region,
     });
-    await createAppVersionsForGroup(client, props);
-    await preDeployHealthcheck(client, props);
+    await createAppVersionsForGroup(client, props, log);
+    await preDeployHealthcheck(client, props, log);
     return client;
   } catch (e) {
     log.error(chalk.red(e));
@@ -155,17 +158,17 @@ async function preDeploySteps(props: IDeployToGroupProps): Promise<ElasticBeanst
  * Beanstalk Environment in the group, then verifies they reach a healthy state
  * and successfully land the expected version.
  */
-async function deploySteps(client: ElasticBeanstalkClient, props: IDeployToGroupProps) {
+async function deploySteps(client: ElasticBeanstalkClient, props: IDeployToGroupProps, log: Logger) {
   let deployErrs: DBError = new DBError('deploySteps(): ', []);
   try {
-    await deployAppVersionsToGroup(client, props);
+    await deployAppVersionsToGroup(client, props, log);
   } catch (e) {
     // We still want to see status of Beanstalks who did have deploy triggered
     deployErrs.errors.push(e as Error);
   }
 
   try {
-    await postDeployHealthcheck(client, props);
+    await postDeployHealthcheck(client, props, log);
   } catch (e) {
     log.error(chalk.red(e));
     if (e instanceof DBError) {
@@ -183,10 +186,10 @@ async function deploySteps(client: ElasticBeanstalkClient, props: IDeployToGroup
  * Versions for their respective Beanstalk Applications, and then deploys
  * those versions to the Beanstalk Environments and verifies their health.
  */
-export async function deployToGroup(props: IDeployToGroupProps) {
+export async function deployToGroup(props: IDeployToGroupProps, log: Logger = loglevel) {
   const group = props.group;
-  log.setLevel(props.logLevel ?? log.levels.INFO);
+  log.setLevel(props.logLevel ?? 'info');
   log.info(chalk.green('Beginning deploy process for beanstalk group ') + chalk.blue(group.name));
 
-  await deploySteps(await preDeploySteps(props), props);
+  await deploySteps(await preDeploySteps(props, log), props, log);
 }

--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -130,15 +130,29 @@ async function deployAppVersionsToGroup(client: ElasticBeanstalkClient, props: I
 }
 
 /**
+ * Get AWS Credentials if provided
+ */
+function getCredentials(props: IDeployToGroupProps) {
+  if (props.accessKeyId && props.secretAccessKey) {
+    return {
+      accessKeyId: props.accessKeyId,
+      secretAccessKey: props.secretAccessKey,
+    };
+  }
+  return;
+}
+/**
  * Initializes the Beanstalk Client, creates the needed Application Versions,
  * and verifies the Beanstalk Environments in the group are ready to receive
  * the deployment.
  */
 async function preDeploySteps(props: IDeployToGroupProps, log: Logger): Promise<ElasticBeanstalkClient> {
   try {
+    const credentials = getCredentials(props);
     const client = new ElasticBeanstalkClient({
       maxAttempts: AWS_CLIENT_REQUEST_MAX_ATTEMPTS_DEFAULT,
       region: props.group.region,
+      credentials,
     });
     await createAppVersionsForGroup(client, props, log);
     await preDeployHealthcheck(client, props, log);

--- a/src/helpers/Interfaces.ts
+++ b/src/helpers/Interfaces.ts
@@ -97,6 +97,14 @@ export interface IDeployToGroupProps {
    * Configuration for health checks after the deployment.
    */
   readonly postDeployHealthCheckProps?: IHealthCheckProps;
+  /**
+   * AWS Access Key Id, if not present taken from i.e. ENV variable
+   */
+  readonly accessKeyId?: string;
+  /**
+   * AWS Secret Access Key, if not present taken from i.e. ENV variable
+   */
+  readonly secretAccessKey?: string;
 }
 
 export interface Logger {

--- a/src/helpers/Interfaces.ts
+++ b/src/helpers/Interfaces.ts
@@ -1,5 +1,6 @@
 import { S3Location, EnvironmentHealthStatus } from '@aws-sdk/client-elastic-beanstalk';
-import log from 'loglevel';
+
+export type LogLevel = 'trace' | 'debug' | 'info' | 'warn' | 'error' | 'silent';
 
 /**
  * Properties consumed to deploy an Application Version to an existing
@@ -87,7 +88,7 @@ export interface IDeployToGroupProps {
   /**
    * Every level below the specified log level is silenced. Defaults to INFO.
    */
-  readonly logLevel?: log.LogLevelDesc;
+  readonly logLevel?: LogLevel;
   /**
    * Configuration for health checks prior to the deployment.
    */
@@ -96,4 +97,12 @@ export interface IDeployToGroupProps {
    * Configuration for health checks after the deployment.
    */
   readonly postDeployHealthCheckProps?: IHealthCheckProps;
+}
+
+export interface Logger {
+  debug: (msg: string | Error) => void;
+  info: (msg: string | Error) => void;
+  warn: (msg: string | Error) => void;
+  error: (msg: string | Error) => void;
+  setLevel: (level: LogLevel) => void;
 }

--- a/src/helpers/Interfaces.ts
+++ b/src/helpers/Interfaces.ts
@@ -1,6 +1,6 @@
 import { S3Location, EnvironmentHealthStatus } from '@aws-sdk/client-elastic-beanstalk';
 
-export type LogLevel = 'trace' | 'debug' | 'info' | 'warn' | 'error' | 'silent';
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error' | 'silent';
 
 /**
  * Properties consumed to deploy an Application Version to an existing
@@ -108,9 +108,9 @@ export interface IDeployToGroupProps {
 }
 
 export interface Logger {
-  debug: (msg: string | Error) => void;
-  info: (msg: string | Error) => void;
-  warn: (msg: string | Error) => void;
-  error: (msg: string | Error) => void;
+  debug: (msg: string) => void;
+  info: (msg: string) => void;
+  warn: (msg: string) => void;
+  error: (msg: string) => void;
   setLevel: (level: LogLevel) => void;
 }

--- a/src/helpers/deploy-app-version-to-env.ts
+++ b/src/helpers/deploy-app-version-to-env.ts
@@ -1,25 +1,24 @@
-/* eslint-disable no-console */
 import { ElasticBeanstalkClient, UpdateEnvironmentCommand } from '@aws-sdk/client-elastic-beanstalk';
-import log from 'loglevel';
 import { DBTriggerDeployError } from './Errors';
-import { IAppVersionProps, IBeanstalkEnvironment } from './Interfaces';
+import { IAppVersionProps, IBeanstalkEnvironment, Logger } from './Interfaces';
 
 interface IDeployProps {
   client: ElasticBeanstalkClient;
   force: boolean;
   env: IBeanstalkEnvironment;
   version: IAppVersionProps;
+  log: Logger;
 }
 
 async function deployApplicationVersion(props: IDeployProps): Promise<void> {
   if (!props.force) {
-    log.info(
+    props.log.info(
       `DRY RUN: Would have deployed app version ${props.version.label} to beanstalk environment ${props.env.name}`,
     );
     return;
   }
 
-  log.info(`Initiating deployment of version ${props.version.label} to environment ${props.env.name}...`);
+  props.log.info(`Initiating deployment of version ${props.version.label} to environment ${props.env.name}...`);
   const resp = await props.client.send(
     new UpdateEnvironmentCommand({
       ApplicationName: props.env.app,
@@ -31,7 +30,7 @@ async function deployApplicationVersion(props: IDeployProps): Promise<void> {
   // Verify deployment initiated successfully
   const statusCode = resp.$metadata.httpStatusCode;
   if (statusCode && statusCode >= 200 && statusCode < 300) {
-    log.info(`Deployment of app version '${props.version.label}' triggered for '${props.env.name}'.`);
+    props.log.info(`Deployment of app version '${props.version.label}' triggered for '${props.env.name}'.`);
   } else {
     throw new Error(`Response metadata: ${JSON.stringify(resp.$metadata, undefined, 2)}`);
   }

--- a/test/deploy.test.ts
+++ b/test/deploy.test.ts
@@ -6,7 +6,6 @@ import {
   UpdateEnvironmentCommand,
 } from '@aws-sdk/client-elastic-beanstalk';
 import { mockClient } from 'aws-sdk-client-mock';
-import { LogLevelDesc } from 'loglevel';
 import {
   DBError,
   DBCreateApplicationVersionError,
@@ -16,13 +15,14 @@ import {
   IDeployToGroupProps,
   DBTriggerDeployError,
   DBGroupDeployTriggerError,
+  LogLevel,
 } from '../src/index';
 
 const ebMock = mockClient(ElasticBeanstalkClient);
 
 const COMMON_DEPLOY_PROPS = {
   force: true,
-  logLevel: 'SILENT' as LogLevelDesc,
+  logLevel: 'silent' as LogLevel,
   preDeployHealthCheckProps: {
     attempts: 1,
     timeBetweenAttemptsMs: 0,


### PR DESCRIPTION
Adds ability to inject external logger (i.e. github actions core logger) and allow externally injected credentials to AWS instead of just env variables.